### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/pwmorreale/rapid/security/code-scanning/2](https://github.com/pwmorreale/rapid/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so token privileges are least-privilege and documented.  
Best fix here: set workflow-level permissions to `contents: read`, which is sufficient for checkout and typical CI read operations. Since the job only builds/tests/lints and uploads artifacts (artifact upload does not require repository write scope), no additional write scopes are needed.

Edit **`.github/workflows/makefile.yml`** by inserting:

- `permissions:`
- `contents: read`

near the top level (after `on:` block and before `jobs:`), so it applies to all jobs unless overridden later.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
